### PR TITLE
Fix HLS preview routing: use Hls.isSupported() in Chrome/Firefox/Edge

### DIFF
--- a/app/web_template.py
+++ b/app/web_template.py
@@ -3164,10 +3164,18 @@ def get_web_ui_html(current_settings=None):
             const protocol = window.location.protocol === 'https:' ? 'https:' : 'http:';
             const streamUrl = `http://${{serverIp}}:8888/${{pathName}}_sub/index.m3u8${{credentials}}`;
             
-            if (videoElement.canPlayType('application/vnd.apple.mpegurl')) {{
-                // Native HLS support (Safari)
+            // Browser routing: prefer hls.js wherever MSE for H.264 is available
+            // (Chrome / Firefox / Edge / Android). canPlayType('vnd.apple.mpegurl')
+            // returns "maybe" in Chrome — a truthy string — even though Chrome
+            // cannot actually decode HLS in <video> natively. Routing on
+            // canPlayType alone silently breaks playback for ~80% of users.
+            // Hls.isSupported() is the only reliable check; fall back to native
+            // HLS only when hls.js can't run (Safari/iOS, where Apple restricts
+            // MSE for H.264 but the <video> element has native HLS).
+            if ((typeof Hls === 'undefined' || !Hls.isSupported()) && videoElement.canPlayType('application/vnd.apple.mpegurl')) {{
+                // Native HLS (Safari / iOS)
                 videoElement.src = streamUrl;
-            }} else if (typeof Hls !== 'undefined') {{
+            }} else if (typeof Hls !== 'undefined' && Hls.isSupported()) {{
                 // Optimized HLS.js configuration for multiple cameras
                 const hlsConfig = {{
                     debug: false,


### PR DESCRIPTION
## Problem

Live preview tiles on the dashboard never load any video in Chrome
(tested on Chrome 147). Tile stays blank, no console error, no
broken-image icon. Safari works fine.

## Root cause

`app/web_template.py:3167` picks between native HLS and hls.js using
`videoElement.canPlayType('application/vnd.apple.mpegurl')`. Chrome
returns `"maybe"` for that MIME — a truthy string — so the
"Safari native HLS" branch runs. The browser fetches the m3u8, parses
the master (videoWidth/Height get set), then silently fails to render
any frame. hls.js is on the page but never gets attached.

## Fix

Check `Hls.isSupported()` first; fall back to native HLS only when
hls.js can't run. This is the pattern from hls.js's own README —
`canPlayType` is unreliable for HLS. Safari/iOS still hit the
native-HLS branch because they lack MSE for H.264 and
`Hls.isSupported()` returns false there.

Bodies of both branches unchanged; only the `if/else if` conditions
are reordered.

## Scope

Single file, +11/-3 in `app/web_template.py`. No API/config/schema
changes.